### PR TITLE
Update site to reflect Lead QE / SDET resume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 **/.DS_Store
+
+# Personal / local files — keep out of the public repo
+*.docx
+*.pdf
+Screenshot*.png

--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Laxminarayana Boga — Lead Software Engineer with 10+ years in test automation, full-stack development, and SaaS products. Based in London.">
-    <meta property="og:title" content="Laxminarayana Boga — Software Engineer">
-    <meta property="og:description" content="Lead Software Engineer with 10+ years across quality engineering and full-stack development. Currently at Cognizant, London.">
+    <meta name="description" content="Laxminarayana Boga — Lead Quality Engineer & SDET with 13 years in test automation, AI-first engineering, and full-stack development. Based in London.">
+    <meta property="og:title" content="Laxminarayana Boga — Lead Quality Engineer & SDET">
+    <meta property="og:description" content="Lead Quality Engineer & SDET with 13 years across test automation architecture, cloud-native CI/CD, and AI-first engineering. London, UK.">
     <meta property="og:type" content="website">
-    <title>Laxminarayana Boga — Software Engineer</title>
+    <title>Laxminarayana Boga — Lead Quality Engineer & SDET</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
@@ -39,10 +39,11 @@
             <div class="hero-text">
                 <p class="hero-greeting">Hi, I'm</p>
                 <h1 class="hero-name">Laxminarayana Boga</h1>
-                <h2 class="hero-title">Lead Software Engineer</h2>
+                <h2 class="hero-title">Lead Quality Engineer &middot; SDET</h2>
                 <p class="hero-description">
-                    10+ years building quality-first software — from enterprise test automation
-                    platforms to full-stack SaaS products. Currently at Cognizant, London.
+                    13 years building quality-first software — designing test automation frameworks,
+                    cloud-native CI/CD quality gates, and AI-first engineering workflows. Leading QE at a
+                    London fintech.
                 </p>
                 <div class="hero-cta">
                     <a href="#contact" class="btn btn-primary">Get in touch</a>
@@ -59,14 +60,19 @@
         <div class="section-container">
             <h2 class="section-title">About</h2>
             <div class="about-content">
-                <p>I'm a software engineer with over a decade of experience across quality engineering, test automation,
-                    and full-stack development. I've worked with global teams across the UK and India, delivering
-                    automation frameworks and web applications for enterprises in real estate, fintech, and retail.</p>
-                <p>My engineering focus sits at the intersection of quality and product — I care about building things
-                    that are well-tested, maintainable, and actually solve problems. Lately that's meant leading quality
-                    engineering at Cognizant while building SaaS products on the side.</p>
-                <p>I write JavaScript end-to-end: Node.js and MongoDB on the backend, React on the frontend, and
-                    WebDriverIO/Selenium for automation. I'm also comfortable on AWS for infrastructure.</p>
+                <p>I'm a Lead Quality Engineer and SDET with 13 years in software testing and automation, including 4+
+                    years in the UK. As the first QE hire at a high-growth London fintech, I built the company-wide
+                    Quality Engineering function — vision, governance, strategy and automation platform — from the ground
+                    up.</p>
+                <p>I design UI, API and database automation frameworks from scratch with tools like Playwright,
+                    WebdriverIO, Cypress, Selenium and Rest Assured, and I'm a strong programmer in Java (9+ years,
+                    Oracle certified) and JavaScript/Node.js. I build cloud-native CI/CD quality gates on AWS that run
+                    impacted tests on every pull request, and operate a nightly regression of 5,000+ end-to-end tests
+                    that finishes in under two hours.</p>
+                <p>I'm an AI-first engineer — I work daily with Claude Code and enterprise GitHub Copilot, building
+                    custom agents and MCP integrations for test authoring, coverage analysis and Agile workflows. In my
+                    own time I build full-stack AI side projects, from RAG chatbots to a modern HR SaaS platform, to push
+                    the limits of applied AI.</p>
             </div>
         </div>
     </section>
@@ -77,52 +83,62 @@
             <div class="timeline">
                 <div class="timeline-item">
                     <div class="timeline-meta">
-                        <span class="timeline-period">2022 — Present</span>
+                        <span class="timeline-period">2024 — Present</span>
                         <span class="timeline-location">London, UK</span>
                     </div>
                     <div class="timeline-body">
-                        <h3 class="timeline-company">Cognizant Technology Solutions</h3>
+                        <h3 class="timeline-company">MyFinance Club</h3>
                         <p class="timeline-role">Lead Quality Engineer</p>
                     </div>
                 </div>
                 <div class="timeline-item">
                     <div class="timeline-meta">
+                        <span class="timeline-period">2022 — 2024</span>
+                        <span class="timeline-location">London, UK</span>
+                    </div>
+                    <div class="timeline-body">
+                        <h3 class="timeline-company">Cognizant</h3>
+                        <p class="timeline-role">Senior Associate — Lead QE / SDET</p>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-meta">
                         <span class="timeline-period">2019 — 2022</span>
-                        <span class="timeline-location">Hyderabad, India</span>
+                        <span class="timeline-location">India</span>
                     </div>
                     <div class="timeline-body">
                         <h3 class="timeline-company">CBRE</h3>
-                        <p class="timeline-role">Software Engineer</p>
+                        <p class="timeline-role">Software Quality Engineer</p>
                     </div>
                 </div>
                 <div class="timeline-item">
                     <div class="timeline-meta">
                         <span class="timeline-period">2019</span>
-                        <span class="timeline-location">Hyderabad, India</span>
+                        <span class="timeline-location">India</span>
                     </div>
                     <div class="timeline-body">
                         <h3 class="timeline-company">GAP Inc.</h3>
-                        <p class="timeline-role">Software Engineer</p>
+                        <p class="timeline-role">Senior Systems Analyst</p>
                     </div>
                 </div>
                 <div class="timeline-item">
                     <div class="timeline-meta">
                         <span class="timeline-period">2017 — 2019</span>
-                        <span class="timeline-location">Hyderabad, India</span>
+                        <span class="timeline-location">India</span>
                     </div>
                     <div class="timeline-body">
-                        <h3 class="timeline-company">DBS DAH2</h3>
-                        <p class="timeline-role">Software Engineer</p>
+                        <h3 class="timeline-company">DBS (Development Bank of Singapore)</h3>
+                        <p class="timeline-role">Quality Assurance Engineer</p>
                     </div>
                 </div>
                 <div class="timeline-item">
                     <div class="timeline-meta">
                         <span class="timeline-period">2013 — 2016</span>
-                        <span class="timeline-location">Hyderabad, India</span>
+                        <span class="timeline-location">India</span>
                     </div>
                     <div class="timeline-body">
                         <h3 class="timeline-company">Cognizant Technology Solutions</h3>
-                        <p class="timeline-role">Software Engineer</p>
+                        <p class="timeline-role">Associate — QA Engineer</p>
                     </div>
                 </div>
             </div>
@@ -134,41 +150,71 @@
             <h2 class="section-title">Skills</h2>
             <div class="skills-grid">
                 <div class="skill-group">
-                    <h3>Automation & QA</h3>
+                    <h3>Test Automation</h3>
                     <div class="skill-tags">
-                        <span>Selenium</span>
-                        <span>WebDriverIO</span>
+                        <span>Playwright</span>
+                        <span>WebdriverIO</span>
                         <span>Cypress</span>
-                        <span>Jest</span>
-                        <span>REST API Testing</span>
-                        <span>BDD / TDD</span>
+                        <span>Selenium</span>
+                        <span>Cucumber</span>
+                        <span>Karate</span>
+                        <span>Rest Assured</span>
+                        <span>BDD / POM</span>
                     </div>
                 </div>
                 <div class="skill-group">
-                    <h3>Backend</h3>
+                    <h3>Languages</h3>
                     <div class="skill-tags">
+                        <span>Java</span>
+                        <span>JavaScript / TypeScript</span>
                         <span>Node.js</span>
-                        <span>Express.js</span>
-                        <span>MongoDB</span>
-                        <span>REST APIs</span>
-                    </div>
-                </div>
-                <div class="skill-group">
-                    <h3>Frontend</h3>
-                    <div class="skill-tags">
-                        <span>JavaScript</span>
+                        <span>SQL</span>
                         <span>React</span>
-                        <span>HTML / CSS</span>
-                        <span>Bootstrap</span>
                     </div>
                 </div>
                 <div class="skill-group">
-                    <h3>Cloud & Tools</h3>
+                    <h3>CI/CD & Cloud</h3>
                     <div class="skill-tags">
                         <span>AWS</span>
-                        <span>Git</span>
-                        <span>CI/CD</span>
+                        <span>GitHub Actions</span>
+                        <span>Jenkins</span>
+                        <span>Azure DevOps</span>
+                        <span>Docker</span>
+                        <span>Terraform</span>
+                        <span>AWS CDK</span>
+                    </div>
+                </div>
+                <div class="skill-group">
+                    <h3>Performance & Quality</h3>
+                    <div class="skill-tags">
+                        <span>K6</span>
+                        <span>JMeter</span>
+                        <span>SonarQube</span>
+                        <span>WireMock</span>
+                        <span>Datadog</span>
+                        <span>Accessibility</span>
+                    </div>
+                </div>
+                <div class="skill-group">
+                    <h3>AI & Tooling</h3>
+                    <div class="skill-tags">
+                        <span>Claude Code</span>
+                        <span>GitHub Copilot</span>
+                        <span>Custom AI Agents</span>
+                        <span>MCP</span>
+                        <span>LangChain</span>
+                        <span>RAG</span>
+                    </div>
+                </div>
+                <div class="skill-group">
+                    <h3>Process & Data</h3>
+                    <div class="skill-tags">
                         <span>Agile / Scrum</span>
+                        <span>JIRA</span>
+                        <span>Confluence</span>
+                        <span>SQL Server</span>
+                        <span>PostgreSQL</span>
+                        <span>MongoDB</span>
                     </div>
                 </div>
             </div>
@@ -181,26 +227,44 @@
             <div class="projects-grid">
                 <div class="project-card">
                     <div class="project-header">
-                        <h3>HRApp</h3>
-                        <span class="project-status in-progress">In development</span>
+                        <h3>Chatbot Sandbox</h3>
                     </div>
-                    <p class="project-description">A SaaS HR management platform built on AWS. Covers employee
-                        lifecycle, onboarding workflows, and HR operations for small to mid-size teams.</p>
+                    <p class="project-description">An AI customer-service sandbox for a fictitious UK home-insurance
+                        provider, demonstrating regulated chatbot patterns — deflection, guardrails and identity
+                        handling — with a self-service bot and live-agent handoff via Amazon Connect. Synthetic data
+                        only.</p>
                     <div class="project-stack">
-                        <span>Node.js</span>
-                        <span>React</span>
-                        <span>MongoDB</span>
+                        <span>OpenAI</span>
+                        <span>Amazon Connect</span>
                         <span>AWS</span>
                     </div>
                 </div>
-                <div class="project-card project-card--placeholder">
+                <div class="project-card">
                     <div class="project-header">
-                        <h3>More coming</h3>
+                        <h3>HRApp</h3>
+                        <span class="project-status in-progress">In development</span>
                     </div>
-                    <p class="project-description">20+ products in the pipeline. Building in public — watch GitHub for
-                        updates.</p>
-                    <a href="https://github.com/laxminarayanaboga" target="_blank"
-                        class="project-link">github.com/laxminarayanaboga →</a>
+                    <p class="project-description">A modern HR SaaS platform for the UK market, covering the employee
+                        lifecycle, onboarding workflows, and HR operations for small to mid-size teams.</p>
+                    <div class="project-stack">
+                        <span>React</span>
+                        <span>Spring Boot</span>
+                        <span>PostgreSQL</span>
+                        <span>AWS</span>
+                    </div>
+                </div>
+                <div class="project-card">
+                    <div class="project-header">
+                        <h3>Knowledge Assistant</h3>
+                    </div>
+                    <p class="project-description">An internal RAG chatbot that retrieves technical and organizational
+                        knowledge from Confluence using OpenAI embeddings and LangChain, deployed on AWS ECS.</p>
+                    <div class="project-stack">
+                        <span>OpenAI</span>
+                        <span>LangChain</span>
+                        <span>Python</span>
+                        <span>AWS ECS</span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -220,9 +284,11 @@
                 <a href="https://github.com/laxminarayanaboga" target="_blank" title="GitHub">
                     <i class="fa-brands fa-github"></i>
                 </a>
-                <a href="https://developers.google.com/profile/u/108461687167861174432" target="_blank"
-                    title="Google Developer Profile">
-                    <i class="fa-brands fa-google"></i>
+                <a href="https://medium.com/@laxminarayanaboga4079" target="_blank" title="Medium">
+                    <svg viewBox="0 0 24 24" width="1.1em" height="1.1em" fill="currentColor" aria-hidden="true"
+                        focusable="false" style="vertical-align: -0.1em;">
+                        <path d="M13.54 12a6.8 6.8 0 0 1-6.77 6.82A6.8 6.8 0 0 1 0 12a6.8 6.8 0 0 1 6.77-6.82A6.8 6.8 0 0 1 13.54 12zM20.96 12c0 3.54-1.51 6.42-3.38 6.42-1.87 0-3.39-2.88-3.39-6.42s1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z" />
+                    </svg>
                 </a>
             </div>
             <p class="footer-copy">© 2026 Laxminarayana Boga</p>


### PR DESCRIPTION
Refreshes the portfolio to match the current resume ahead of job applications.

## Changes
- **Hero / meta / About** — current role (Lead QE / SDET), 13 years' experience, leading QE at a London fintech; removed stale "Cognizant / 10+ years" copy
- **Experience** — accurate titles and dates, added MyFinance Club (2024–Present)
- **Skills** — reorganised into QE/SDET-focused groups (Playwright, Java, CI/CD & Cloud, Performance & Quality, AI & Tooling)
- **Projects** — Chatbot Sandbox, HRApp (corrected stack), Knowledge Assistant
- **Contact** — replaced Google Developer link with Medium (inline SVG icon for reliable rendering)
- **.gitignore** — exclude personal docx/pdf/screenshot files

🤖 Generated with [Claude Code](https://claude.com/claude-code)